### PR TITLE
Typos and Possible Improvements

### DIFF
--- a/ha/7-balance.typ
+++ b/ha/7-balance.typ
@@ -100,7 +100,7 @@ This isomorphism is called the *balancing of $Ext$*. Before proving the balancin
   $ Tor_i^R (A, B) = Tor_i^R (-, B)(A) := L_i (- tpr B) (A). $
 ]
 
-Similarly, let $A$ be a right $R$-module, and $(A tpr - ): RMod -> Ab$ is right exact by @tensor-right-exact-2. We can thus define the left derived functor $Tor_i^R (A, -)$:
+Similarly, let $A$ be a right $R$-module, so that $(A tpr - ): RMod -> Ab$ is right exact by @tensor-right-exact-2. We can thus define the left derived functor $Tor_i^R (A, -)$:
 $
   Tor_i^R (A, -)(B) := L_i (A tpr -) (B).
 $
@@ -168,8 +168,8 @@ In order to prove the balancing of $Ext$ and $Tor$, we need two new tools: mappi
   //   ... -> H^(n-1) (cone(f)) ->  H^n (B) ->^diff H^n (C) -> H^n (cone(f)) -> ...
   // $
   // with $diff = g^ast$.
-
 ]
+<cone-les>
 #proof[
   There is a #sest of chain complexes:
   $ ses(C, cone(f), B[-1], f: i, g: pi), $
@@ -185,7 +185,7 @@ The following is the main function of the mapping cone.
 ]
 <cone-qi>
 #proof[
-  "$=>$". If $f$ is a quasi-isomorphism, then $f_ast : H_n (B) -> H_n (C)$ is an isomorphism for all $n$. Then we have an exact
+  "$=>$". If $f$ is a quasi-isomorphism, then $f_ast : H_n (B) -> H_n (C)$ is an isomorphism for all $n$. By @cone-les, we have an exact
   sequence
   $
     H_n (B) arrow.r^(f_ast) H_n (C) arrow.r^(i_ast) H_n ("cone"(f)) arrow.r^(pi_ast) H_(n - 1) (B) arrow.r^(f_ast) H_(n - 1) (C).
@@ -563,9 +563,9 @@ A variant of the above lemma is the following, whose proof is similar @notes[Lem
 #proof[ @weibel[Theorem 2.7.2].
   // #align(center,image("../imgs/2023-11-23-03-00-04.png",width:80%))
   (We drop the dots for chain complexes in this proof.)
-  Choose a projective resolution $P_cx rgt(epsilon) A$ in $ModR$ and a project resolution $Q_cx rgt(eta) B$ in $RMod$.
+  Choose a projective resolution $P_cx rgt(epsilon) A$ in $ModR$ and a projective resolution $Q_cx rgt(eta) B$ in $RMod$.
   We can view $A, B$ as chain complexes concentrated in degree $0$. Now consider the double complexes $P tpr Q$, $A tpr Q$ and $P tpr B$, and we have _bicomplex morphisms_ (where it might be helpful to recall the diagram in @resolution-qi): 
-  $ epsilon tp id_Q: P tpr Q -> A tpr Q, \ id_Q tp eta: P tpr Q -> P tpr B, $ 
+  $ epsilon tp id_Q: P tpr Q -> A tpr Q, \ id_P tp eta: P tpr Q -> P tpr B, $ 
   which induce chain maps on the total complexes:
   $
     f : Tot^xor (P tpr Q) -> Tot^xor (A tpr Q) = A tpr Q, \
@@ -643,7 +643,7 @@ A variant of the above lemma is the following, whose proof is similar @notes[Lem
   $
   for $f in hom ( P_p , I^q )$.
 
-  Then we define the *Hom cochain complex*#footnote[@weibel[p. 62] writes this as $Tor^Pi (hom (P, I))$, but as we will see in this case any diagonal slice has only finite terms, so their product and direct sum are the same.] as
+  Then we define the *Hom cochain complex*#footnote[@weibel[p. 62] writes this as $Tor^Pi (hom (P, I))$, but as we will see in this case any diagonal slice has only finitely many terms, so their product and direct sum are the same.] as
 
   $ Tot^xor (hom(P, I)). $
 ]

--- a/ha/9-tor.typ
+++ b/ha/9-tor.typ
@@ -73,7 +73,7 @@
   $
   which shows that $(- tpr B)$ is exact.
 
-  Note that #rrm case relies on the balancing of $Tor$, but the proof is very similar.
+  Note that the #rrm case uses the balancing of $Tor$, but the proof is very similar.
 ]
 
 #corollary[Every projective module is flat. In particular, every free module is flat. #footnote[We have already proven this claim in @projective-flat-1, because we needed it for the balancing of $Tor$ (@balance-tor). This second proof actually relies on the balancing of $Tor$ so we could not use it previously, but it is presented here regardless.]]
@@ -170,7 +170,7 @@
 #proof[
   @weibel[Theorem 3.2.2, p.69].
 ]
-We now take a look at the case in $Ab$ and we shall show that a module in $Ab$ is flat if and only if it is torsion-free.
+We now take a look at the case $Ab$ and we shall show that a module in $Ab$ is flat if and only if it is torsion-free.
 #lemma[
   Let $B in Ab$ and $p in ZZ$. Then
   $Tor_0^ZZ (ZZ over p ZZ, B) = B over p B$ and $Tor_1 ^ZZ (ZZ over p ZZ, B) = {b in B : p b = 0}.$
@@ -278,7 +278,7 @@ We now take a look at the case in $Ab$ and we shall show that a module in $Ab$ i
 ]
 
 #remark[
-  Why have we not defined $Tor$ with flat resolutions in the first place? The problem is that we have to show it is well defined regardless of the choice of flat resolutions. This may not be as convenient as using projective resolutions. Nevertheless, now we are free to use flat resolutions, a larger class than projective resolutions, for calculations.
+  Why have we not defined $Tor$ with flat resolutions in the first place? The problem is that we have to show it is well defined, independent of the choice of flat resolutions. This may not be as convenient as using projective resolutions. Nevertheless, now we are free to use flat resolutions, a larger class than projective resolutions, for calculations.
 ]
 
 A generalisation to flat modules is the following.

--- a/ha/c-gc.typ
+++ b/ha/c-gc.typ
@@ -140,7 +140,7 @@ $G$ with coefficients in $A$* as the right derived functors of $(-_G)$:
   and the *abelianisation* of $G$ is $G over [G, G]$.
 ]
 
-The aim is of this section is to show that $H_1 (G, ZZ) iso G over [G, G]$ for any group $G$.
+The aim of this section is to show that $H_1 (G, ZZ) iso G over [G, G]$ for any group $G$.
 
 #definition[
   The *augmentation ideal* $frak(J)$ of $ZZ G$ is defined as the kernel of the ring map
@@ -247,7 +247,7 @@ The aim is of this section is to show that $H_1 (G, ZZ) iso G over [G, G]$ for a
 ]
 #lemma[$N$ is a central element of $ZZ G$ and $N in lr((bb(Z) G))^G$.]
 #proof[
-  For every $h in G$, we have $h N = sum_g h g$, but left multiplication by $h$ is an automorphism of $G$ (by Cayley's theorem), so $h N = sum_(g') g' = N$ by reindexing. Similarly, $N h = N$.
+  For every $h in G$, we have $h N = sum_g h g$, but left multiplication by $h$ is an automorphism of $G$ (whose inverse is left multiplication by $h^(-1)$), so $h N = sum_(g') g' = N$ by reindexing. Similarly, $N h = N$.
 ]
 
 #lemma[
@@ -274,7 +274,7 @@ The aim is of this section is to show that $H_1 (G, ZZ) iso G over [G, G]$ for a
   $
     N a = (sum_(h in G) h) (sum_(g in G) n_g g) = sum_(h in G) sum_(g in G) n_g (h g) = sum_(g' in G) sum_(g in G) n_g g' \ = sum_(g' in G) (sum_(g in G) n_g) g' = (sum_(g in G) n_g) (sum_(g' in G) g') = (sum_(g in G) n_g) N.
   $
-  Therefore $N a = 0$ if and only if $sum_(g in G) n_g = 0$, #iff $a in fJ$.
+  Therefore, $N a = 0$ if and only if $sum_(g in G) n_g = 0$, #iff $a in fJ$.
   The image of $ZZ G ->^N ZZ G$ is also clear from above, since $(sum_(g in G) n_g)$ can take all values in $ZZ$.
 ]
 


### PR DESCRIPTION
The explanation for my proposed change to proof of Lemma 13.3.3, line 2 is that we do not need Cayley's theorem to show that left multiplication by $h$ is an automorphism of $G$: It suffices to say that its inverse is left multiplication by $h^{-1}$.

Thank you in advance for looking into these.