### PR TITLE
fix: mix use of final and terminal object

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
 
       # Step 1: Download the typst archive
       - name: Download Typst
-        run: wget https://github.com/typst/typst/releases/download/v0.12.0/typst-x86_64-unknown-linux-musl.tar.xz
+        run: wget https://github.com/typst/typst/releases/download/v0.13.1/typst-x86_64-unknown-linux-musl.tar.xz
 
       # Step 2: Extract the typst archive
       - name: Extract Typst

--- a/ha/1-cat.typ
+++ b/ha/1-cat.typ
@@ -83,7 +83,7 @@ In general, a category is a "generalised" monoid because in a category you can o
 #definition[
   An *initial object* $I$ of category $cC$ is an object such that for any $A in ob cC$, there exists a unique morphism $I -> A$.
 
-  A *final object* $T$ is an object such that for any $A in ob cC$ there exists a unique morphism $A -> T$.
+  A *final object* (or *terminal object*) $T$ is an object such that for any $A in ob cC$ there exists a unique morphism $A -> T$.
 ]
 
 #example[

--- a/ha/2-ab.typ
+++ b/ha/2-ab.typ
@@ -58,7 +58,7 @@ An $Ab$-enriched category needs not have a zero object. Nevertheless, once it ha
 #proof[
   (3) $=>$ (1) and (3) $=>$ (2) are obvious. We only prove (1) $=>$ (3), and (2) $=>$ (3) follows from duality.
 
-  Suppose $*$ is a terminal object and let $id_* : * -> *$ be the unique morphism in the abelian group of $Hom(C)(*, *)$, and so $id_* = 0$.
+  Suppose $*$ is a final object and let $id_* : * -> *$ be the unique morphism in the abelian group of $Hom(C)(*, *)$, and so $id_* = 0$.
   For any object $A$ and $f : * -> A$ (because $Hom(C)(*, A) $ contains at least the zero morphism), we have $ f = f compose id_* = f compose 0 = 0 in Hom(C)(*, A). $
   So there is a unique morphism from $*$ to $A$ and therefore $*$ is also initial.
 ]

--- a/ha/2-ab.typ
+++ b/ha/2-ab.typ
@@ -532,9 +532,9 @@ The key element that we seek from an abelian category is the notion of exactness
 
   (2) $=>$ (1). We first claim that $B = IM f + Ker r$. Take any $b in B$, then plainly $b = f r(b) + (b - f r(b)) $. Since $r (b - f r(b)) = r (b) - r f r (b) = 0$, we have $b - f r(b) in Ker r$. Also obviously $f r (b) in IM f$.
 
-  We further claim that $B = IM f ds Ker r$. Suppose $b in IM f sect Ker r$, then there exists $a in A$ such that $b =  f(a)$; also $r (b) = 0$. Then $0 = r f (a) =a$, so $b = f(a) = 0$.
+  We further claim that $B = IM f ds Ker r$. Suppose $b in IM f inter Ker r$, then there exists $a in A$ such that $b =  f(a)$; also $r (b) = 0$. Then $0 = r f (a) =a$, so $b = f(a) = 0$.
 
-  Now we claim that $Ker r iso C$; in particular, the restriction $g|_(Ker r) : Ker r -> C$ is an isomorphism. Take any $c in C$, then since $g$ is a surjection, there exists some $f(a) + k in B$, where $a in A$ and $k in Ker r$, such that $g (f(a) + k) = c$. Note that $g f(a) = 0$, because $f(a) in IM f = Ker g$ by exactness at $B$, so for any $c in C$, there exists $k in Ker r$ such that $g(k) = c$. Thus $g|_(Ker r)$ is surjective. On the other hand, if $g(k) = 0$ for $k in Ker r$, then $k in Ker g = IM f$, but $IM f sect Ker r = {0}$, so $k = 0$. Thus $g|_(Ker r)$ is injective.
+  Now we claim that $Ker r iso C$; in particular, the restriction $g|_(Ker r) : Ker r -> C$ is an isomorphism. Take any $c in C$, then since $g$ is a surjection, there exists some $f(a) + k in B$, where $a in A$ and $k in Ker r$, such that $g (f(a) + k) = c$. Note that $g f(a) = 0$, because $f(a) in IM f = Ker g$ by exactness at $B$, so for any $c in C$, there exists $k in Ker r$ such that $g(k) = c$. Thus $g|_(Ker r)$ is surjective. On the other hand, if $g(k) = 0$ for $k in Ker r$, then $k in Ker g = IM f$, but $IM f inter Ker r = {0}$, so $k = 0$. Thus $g|_(Ker r)$ is injective.
 
   Finally, observe that $f$ is an injection, so $IM(f) iso A$.
 
@@ -543,7 +543,7 @@ The key element that we seek from an abelian category is the notion of exactness
 
 
 #corollary[Let $M, S, T$ be $R$-modules.
-  - If $M = S ds T$ and $S subset.eq N subset.eq M$, then $N = S ds (N sect T)$.
+  - If $M = S ds T$ and $S subset.eq N subset.eq M$, then $N = S ds (N inter T)$.
   - If $M = S ds T$ and $S' subset.eq S$, then $M over S' = S over S' ds (T + S') over S'$.
 ]
 <split-sub>

--- a/ha/4-enough.typ
+++ b/ha/4-enough.typ
@@ -198,7 +198,7 @@ For most of our homological algebra to work, an abelian category needs to have e
   suppose that $a plus b r eq a^prime plus b r^prime$
   where $a, a' in A'$ and $r, r' in R$.
   Then
-  $ a minus a^prime eq b lr((r^prime minus r)) in A^prime sect b R dot.basic $
+  $ a minus a^prime eq b lr((r^prime minus r)) in A^prime inter b R dot.basic $
 
   From this we see $r - r' in I$, and then we have
   $

--- a/libs/template.typ
+++ b/libs/template.typ
@@ -1,4 +1,4 @@
-#import "@preview/commute:0.2.0": node, arr, commutative-diagram
+#import "@preview/commute:0.3.0": node, arr, commutative-diagram
 
 #let color_style = "./color.typ"
 #let link_color = rgb(0, 0, 255)

--- a/main.typ
+++ b/main.typ
@@ -14,7 +14,7 @@
 
 
 
-#outline(indent: true)
+#outline(indent: auto)
 
 #heading(numbering: none)[License]
 


### PR DESCRIPTION
- Update definition of final object to include "terminal object"
- Change reference from terminal to final object in proof section
- Update the Typst version from 0.12.0 to 0.13.1
- Update the commute package from 0.2.0 to 0.3.0
- Minor change to fix some compiling errors